### PR TITLE
Update frontend.md

### DIFF
--- a/frontend.md
+++ b/frontend.md
@@ -7,23 +7,27 @@
 > **Hold** - Technologies in hold must no longer be used for new development
 
 ## Adopt
+
 ### React
-Off-the-shelf tooling, popularity is insane, extremely engaged community, easy to recruit for. Used on External Consultations and Identity Management projects, as well as the Nice Design System.
+Off-the-shelf tooling, popularity is insane, extremely engaged community, easy to recruit for. Used on External Consultations, Identity Management, CKS, Global Nav, as well as the NICE Design System.
 
 ### TypeScript
-Microsoft's superset of JavaScript for static typing. TypeScript is "transcompiled" to JavaScript, showing errors at compilation. Used on Identity Management. The Design System supplies type definitions for TypeScript enabled projects.
+Microsoft's superset of JavaScript for static typing. TypeScript is "transcompiled" to JavaScript, showing errors at compilation. Used on Identity Management and CKS. The Design System supplies type definitions for TypeScript enabled projects.
 
-### Jest + Enzyme
-JS Testing framework. The default test driver for React when using Create-React-App. Enzyme is a testing utility that makes it easy to simulate interactions and assert on the output of React components. Used in consultations, IdAM, and the design system. Also the webdriver.io steps.
+### ESNext
+We should be using modern syntax for JS wherever possible, as long as the code is transpiled before being used in the browser. Babel tooling makes adopting the latest spec recommendations very simple. Although seriously consider [TypeScript](#typescript) over raw ESNext wherever possible.
+
+### Jest
+JS Testing framework. The default test driver for React when using Create-React-App and Gatsby etc. Used in most, if not all our 'modern' JavaScript projects.
+
+### React Testing Library
+React Testing Library replaces [Enzyme](#enzyme) as our library of choice for testing React components because of its [focus on user behaviour rather than internal implementations](https://testing-library.com/docs/react-testing-library/migrate-from-enzyme/#why-should-i-use-the-react-testing-library) of components, great docs and active community.
 
 ### Webpack
-Module bundler for JavaScript (and other assets with plugins). Preferred approach to using JS on any new project or to be retrofitted where feasible.
-
-### ES6 (or whatever is current)
-We should be using modern syntax for JS wherever possible, as long as the code is transpiled before being used in the browser. Babel tooling makes adopting the latest spec recommendations very simple.
+Module bundler for JavaScript (and other assets with plugins). Preferred approach to using JS on any new project or to be retrofitted where feasible. Used on CKS, via Gatsby, Global Nav, CKS, niceorg-client, NICE Design System, Comment Collection and probably others.
 
 ### Sass
-CSS Preprocessor. Used on at least NICE Design System, Pathways and External Consultations.
+CSS Preprocessor. Used on at least NICE Design System, CKS, niceorg-client, Pathways and External Consultations.
 
 ### WebdriverIO
 Front end testing framework. Used in everything. 
@@ -32,23 +36,28 @@ Front end testing framework. Used in everything.
 Currently used in a few projects. For when you want .NET to render the HTML. We generally use React now, but sometimes we will use razor where react is overkill.
 
 ### npm
-Currently standard, but can sometimes be a bit of a pain, so we are assessing yarn. 
+Currently standard, but can sometimes be a bit of a pain. We decided to use this over yarn.
+
+### Gatsby
+CKS uses Gatsby. It provides a great developer experience, is performant, accessible and good for SEO. It has great documentation and large community. Usage of React and TypeScript in tandem with Jest and React Testing Library makes use of the Design System components seemless.
 
 
 ## Assess
+
 ### Redux / Observable patterns / MobX / other state management
 We're not currently using any state management approaches, would be good to assess for the next large single-page-app project.
 
-### Gatsby / other static site generators
-We have some sites that could do we being rewritten, and would be rewritten with a static site generators (eg CKS and BNF). Gatsby currently makes more sense than any other ones.
-
-### Yarn
-Trial to replace npm. **Do not** use both.
-
 ### Browserstack
-cross browser testing
+Used for automated cross browser testing with WebdriverIO in at least 1 project.
+
 
 ## Hold
+
+### Yarn
+We see no reason to use yarn, especially with npm 7 out with Node 16+. People are comfortable with nvm tooling so there's no need to rock the boat with _another_ tool without clear reason. It _might_ be useful with the monorepo in the Design System (using workspaces), but Lerna plugs that gap.
+
+### Enzyme
+Enzyme was the de facto library for testing React components. However, React Testing Library is now more widely used (as of [September 2020](https://www.npmtrends.com/enzyme-vs-@testing-library/react)) and focuses more on behaviour than implementation so results in better tests.
 
 ### jQuery	
 Now we're supporting IE11+, JavaScript in our target browsers is pretty aligned, or easier than ever to compensate for. 
@@ -73,17 +82,17 @@ We are using React
 ### Custom frameworks built on top of things eg hyperbone	
 We are using React
 
-### Backbone	
+### Backbone
 We are using React
 
-### Browserify/Grunt etc	
-For bundling, we use webpack
+### Browserify/Grunt etc
+For bundling, we use [webpack](#webpack)
 
-### Spark, Handlbars.js, nunjucks	
+### Spark, Handlbars.js, nunjucks
 View engines, now out of date. We are using Razor or JSX templating
 
-### Flow	
-Trialled on comment collection, typescript does what flow does but better. Use typescript.
+### Flow
+Trialled on [Comment Collection](https://github.com/nice-digital/consultations), TypeScript does what Flow does but better and with better tooling. Use [TypeScript](#typescript).
 
 ### Mocha
-Used for previous versions of the design system, we use jest and enzyme instead.
+Used for v0 of the Design System, we use Jest instead.

--- a/frontend.md
+++ b/frontend.md
@@ -50,6 +50,11 @@ We're not currently using any state management approaches, would be good to asse
 ### Browserstack
 Used for automated cross browser testing with WebdriverIO in at least 1 project.
 
+### NextJS
+We see the need to have universal apps with Server Side Rendering (SSR) and whilst we're using React, NextJS makes sense. It provides SSR as well as static site generation (SSG) and even Incremental Static Regeneration (ISR) out of the box, has great docs, usage and community.
+
+We used SpaServices in .NET Core 2 to provide server side React rendering, but this is out of support in August 2021. So we need an alternative for server-side rendered React apps, which may well be NextJS. Blitz.js is an interesting alternative worth keeping an eye on (it's currently in beta).
+
 
 ## Hold
 


### PR DESCRIPTION
Retire yarn and enzyme to hold.
Move Gatsby to adopt. 
Add React Testing Library to adopt.
Split Jest out from React Testing Library.
Rename ES6 to ESNext.
Add NextJS.
Update various notes.
